### PR TITLE
Remove recoil from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.2",
-    "recoil": "^0.7.7",
     "stylelint": "^16.1.0",
     "stylelint-config-recommended": "^14.0.0",
     "stylelint-config-sass-guidelines": "^11.0.0",


### PR DESCRIPTION
am not sure if its recoil needed to be part of dev dependencies but in a react native project with React 19 it will break it and cause this build error 
`TypeError: Cannot read property 'ReactCurrentDispatcher' of undefined, js engine: hermes`